### PR TITLE
Explain identical moves

### DIFF
--- a/app/components/TutorialModal.tsx
+++ b/app/components/TutorialModal.tsx
@@ -117,6 +117,11 @@ export default function TutorialModal({
                     wrong. In this case, a knight was played, but not
                     necessarily the same knight.
                   </p>
+                  <p className="text-lg mb-6">
+                    <span className="font-bold">NB!</span> The notation has to
+                    be identical for the moves to be considered the same. Nxf7
+                    and Nxf7+ aren't considered the same.
+                  </p>
                   <p className="my-4 text-lg leading-relaxed font-bold">
                     A new position will appear every day at midnight UTC.
                   </p>


### PR DESCRIPTION
Explain that the notation has to be identical for the moves to be
considered the same.

Close #19