### PR TITLE
Allow user to "go forwards" through move history

### DIFF
--- a/app/components/Chessguessr.tsx
+++ b/app/components/Chessguessr.tsx
@@ -7,9 +7,12 @@ import Modal from "./Modal/Modal";
 import { Game, GameStatus } from "~/utils/types";
 import { useWindowSize } from "~/hooks/useWindowSize";
 import TutorialModal from "./TutorialModal";
-import { useHotkeys } from "react-hotkeys-hook";
 import Countdown from "react-countdown";
-import { countdownRenderer, midnightUtcTomorrow } from "~/utils/utils";
+import {
+  countdownRenderer,
+  midnightUtcTomorrow,
+  useHotkeys,
+} from "~/utils/utils";
 import useCopyToClipboard from "~/hooks/useCopyToClipboard";
 
 const ChessboardWrapper = styled.div`
@@ -69,6 +72,7 @@ export const Chessguessr = ({
     onDrop,
     position,
     takeback,
+    goForwards,
     submitGuess,
     guesses,
     turn,
@@ -108,7 +112,10 @@ export const Chessguessr = ({
   const nextDate = midnightUtcTomorrow();
 
   useHotkeys("Backspace", takeback, [currentGuess, fenHistory]);
+  useHotkeys("Left", takeback, [currentGuess, fenHistory]);
+  useHotkeys("Right", goForwards, [currentGuess, fenHistory]);
   useHotkeys("Enter", submitGuess, [currentGuess]);
+  useHotkeys("Space", submitGuess, [currentGuess]);
 
   return (
     <div>

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -35,3 +35,13 @@ export enum GameStatus {
   SOLVED = "SOLVED",
   FAILED = "FAILED",
 }
+
+export type FullFenHistory = {
+  trueFenHistory: string[];
+  cachedNavigableHistory: string[];
+};
+
+export type GuessWithHistory = {
+  trueGuess: string[];
+  cachedNavigableGuess: string[];
+};

--- a/app/utils/utils.tsx
+++ b/app/utils/utils.tsx
@@ -1,4 +1,5 @@
 import { zeroPad } from "react-countdown";
+import { useHotkeys as _useHotkeys } from "react-hotkeys-hook";
 
 export const arraysEqual = (a: any, b: any) => {
   if (a === b) return true;
@@ -34,3 +35,19 @@ export const countdownRenderer = ({ hours, minutes, seconds }) => (
     {zeroPad(hours)}:{zeroPad(minutes)}:{zeroPad(seconds)}
   </span>
 );
+
+// We re-export useHotkeys with preventDefault on the handler
+export const useHotkeys = (
+  key: string,
+  callback: () => void,
+  deps: any[] = []
+) => {
+  return _useHotkeys(
+    key,
+    (e) => {
+      e.preventDefault();
+      callback();
+    },
+    deps
+  );
+};


### PR DESCRIPTION
Suggested solution to fix https://github.com/Assios/chessguessr/issues/35
(and https://github.com/Assios/chessguessr/issues/34).

The meat of the solution is to keep track of what you have guessed before in a
"cache" for both positions and moves. To do this, we wrap the simple
`setCurrentMove` and `setFenHistory` functions in a layer that writes the cache
every time you make a new/different move, but maintains the cache as long as you
play "the same moves as before" – regardless of _how_ you play them.

This allows "redo" if you have accidentally clicked "undo" too many times.
As an added bonus, after you have placed a guess, you can press "right right
right" to fill in the first three moves of your previous guess. Very convenient
if you already have most of the solution and only need to figure out the final
1-2 moves.

For now (to avoid unsolicited clutter), I have not added a visual UI for the
feature, only added the hotkey arrow-right.
